### PR TITLE
Add baseConfigurationUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are three configuration items you'll need:
 * signingKey
 * integrationKey
 
-With these three things, copy the `config/default.json` to `config/local-development.json` file and fill it in. You may also need to change the `baseConnectUrl` and `baseApiUrl` if you're connecting to a non-production environment.
+With these three things, copy the `config/default.json` to `config/local-development.json` file and fill it in. You may also need to change the `baseConfigurationUrl`, `baseConnectUrl`, and `baseApiUrl` if you're connecting to a non-production environment.
 
 Once setup and running (`npm start`) you'll be presented with a list of users you can "login" as. From there you can kick off a request to connect that user to a project broadcast user. Once connected, some API requests will be made to display some data.
 

--- a/config/default.json
+++ b/config/default.json
@@ -3,6 +3,7 @@
   "partnerId": "",
   "signingKey": "",
   "integrationKey": "",
+  "baseConfigurationUrl": "https://app.projectbroadcast.com/integrations/",
   "baseConnectUrl": "https://app.projectbroadcast.com/integrations/",
   "baseApiUrl": "https://app.projectbroadcast.com/api/v1/"
 }

--- a/lib/project-broadcast.js
+++ b/lib/project-broadcast.js
@@ -57,7 +57,7 @@ export const signedConnectUrlForUser = (user) => {
 export const signedConfigurationUrlForUser = (user) => {
   const params = stampAndSignParams({ pcuid: user.id })
   const urlSearchParams = new URLSearchParams(params)
-  const baseUrl = config.get('baseConnectUrl')
+  const baseUrl = config.get('baseConfigurationUrl')
   const partnerId = config.get('partnerId')
   const url = new URL(`${partnerId}/configuration?${urlSearchParams.toString()}`, baseUrl)
   return url


### PR DESCRIPTION
This facilitates configuration APIs being on a different subdomain than the web connect APIs.